### PR TITLE
Increase gradle timeouts

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-systemProp.org.gradle.internal.http.connectionTimeout=120000
-systemProp.org.gradle.internal.http.socketTimeout=120000
+systemProp.org.gradle.internal.http.connectionTimeout=180000
+systemProp.org.gradle.internal.http.socketTimeout=180000


### PR DESCRIPTION
Sometimes the jitpack build fails with a timeout ([see recent log](https://jitpack.io/com/github/chimp1984/misq/630eaad540/build.log)).

Increasing the gradle timeouts fixes this.